### PR TITLE
Updating the link for DevOps Roadmap to correct URL (https://roadmap.…

### DIFF
--- a/src/data/roadmaps/docker/docker.json
+++ b/src/data/roadmaps/docker/docker.json
@@ -4186,7 +4186,7 @@
                   "x": "23",
                   "y": "52",
                   "properties": {
-                    "controlName": "ext_link:roadmap.sh/best-practices"
+                    "controlName": "ext_link:roadmap.sh/devops"
                   },
                   "children": {
                     "controls": {


### PR DESCRIPTION
…sh/docker) previously set to (https://roadmap.sh/best-practices)